### PR TITLE
Fix name of file to ignore when copying gui template

### DIFF
--- a/src/esmf_profiler/main.py
+++ b/src/esmf_profiler/main.py
@@ -153,7 +153,7 @@ def safe_create_directory(paths):
 
 
 def copy_gui_template(  # pylint: disable=dangerous-default-value
-    output_path, input_path="./web/app/build", _ignore=["site.json", "data.json"]
+    output_path, input_path="./web/app/build", _ignore=["site.json", "load_balance.json"]
 ):
     """copy_gui_template copies the Web GUI template files
 


### PR DESCRIPTION
This fix is needed because the `load_balance.json` file under web/app/build/data was being copied in to the output directory, thereby overwriting the `load_balance.json` file generated by the trace analysis.